### PR TITLE
fix: put obj in arr if we have a single response

### DIFF
--- a/src/services/inventoryservice/index.ts
+++ b/src/services/inventoryservice/index.ts
@@ -31,7 +31,14 @@ const getInventory = async (spaceId?: string): Promise<Inventory[]> => {
     if (!response.fi2simplemessage) {
       return []
     }
-    const result = response.fi2simplemessage.fi2equipment.map(transformEquipment)
+
+    const arrResponse = Array.isArray(response.fi2simplemessage.fi2equipment)
+      ? response.fi2simplemessage.fi2equipment
+      : response.fi2simplemessage.fi2equipment
+      ? [response.fi2simplemessage.fi2equipment]
+      : []
+
+    const result = arrResponse.map(transformEquipment)
     return result
   } catch (err) {
     throw new Error(err as string)


### PR DESCRIPTION
BUG**

Fast Api gives a array if multiple objects and just a object if there is just. one answer.  